### PR TITLE
Allow for callback in value setter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,18 +8,20 @@ type Options<T> = Partial<{
   parser: Parser<T>;
 }>;
 
+type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
+
 type SetKey<T> = (key: string, value?: T) => void;
 
 function useLocalStorage<T>(
   key: string,
   defaultValue: T,
   options?: Options<T>
-): [T, (value: T) => void, SetKey<T>];
+): [T, Setter<T>, SetKey<T>];
 function useLocalStorage<T>(
   key: string,
   defaultValue?: undefined,
   options?: Options<T>
-): [T | undefined, (value: T | undefined) => void, SetKey<T>];
+): [T | undefined, Setter<T | undefined>, SetKey<T>];
 function useLocalStorage<T>(
   key: string,
   defaultValue?: T,
@@ -46,8 +48,11 @@ function useLocalStorage<T>(
 
   const { currentKey, currentValue } = keyValue;
 
-  const setValue = useCallback((value: T) => {
-    setKeyValue(({ currentKey }) => ({ currentKey, currentValue: value }));
+  const setValue = useCallback((value: Setter<T>) => {
+    setKeyValue(({ currentKey, currentValue }) => ({
+      currentKey,
+      currentValue: typeof value === "function" ? value(currentValue) : value,
+    }));
   }, []);
 
   const setKey: SetKey<T> = useCallback(

--- a/test/useLocalStorage.test.tsx
+++ b/test/useLocalStorage.test.tsx
@@ -17,6 +17,14 @@ function TestComponent() {
         Change Username
       </button>
       <button
+        id="set-data-callback"
+        onClick={() => {
+          setData((data) => data + "foo");
+        }}
+      >
+        Change Username
+      </button>
+      <button
         id="set-key"
         onClick={() => {
           setKey("password");
@@ -82,6 +90,13 @@ describe("useLocalStorage", () => {
     fireEvent.click(container.querySelector("#set-data")!);
     expect(container.querySelector("p")).toHaveTextContent("Burt");
     expect(localStorage.__STORE__.username).toBe(JSON.stringify("Burt"));
+  });
+  it("changes localstorage and state value using callback", () => {
+    localStorage.setItem("username", JSON.stringify("Daffodil"));
+    const { container } = render(<TestComponent />);
+    fireEvent.click(container.querySelector("#set-data-callback")!);
+    expect(container.querySelector("p")).toHaveTextContent("Daffodilfoo");
+    expect(localStorage.__STORE__.username).toBe(JSON.stringify("Daffodilfoo"));
   });
   it("changes key and uses default value", () => {
     const { container } = render(<TestComponent />);


### PR DESCRIPTION
Takes care of the `setValue` callback piece of https://github.com/nas5w/use-local-storage/issues/6

The `setKey` callback will need to be thought out a bit more. It's hard to tell what the most intuitive behavior of the `defaultValue` parameter would be.