### PR TITLE
Simplify hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![useLocalStorage React hook](https://raw.githubusercontent.com/nas5w/uselocalstorage/master/uls-logo.png)
+![useLocalStorage React hook](https://raw.githubusercontent.com/nas5w/use-local-storage/master/uls-logo.png)
 
 A flexible React Hook for using Local Storage.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![useLocalStorage React hook](https://raw.githubusercontent.com/nas5w/use-local-storage/master/uls-logo.png)
+![useLocalStorage React hook](https://raw.githubusercontent.com/nas5w/uselocalstorage/master/uls-logo.png)
 
 A flexible React Hook for using Local Storage.
 
@@ -72,50 +72,9 @@ function MyComponent() {
 }
 ```
 
-# Advanced Usage
+# Advanced Usage / Options
 
-The `useLocalStorage` hook has a couple other features:
-
-- Ability to change keys
-- Ability to use a custom parser and/or serializer
-
-## Changing Keys
-
-The `useLocalStorage` hook returns a function as a third array element that lets you set a new `key` with an option (but recommended) second argument for the default value.
-
-```jsx
-import useLocalStorage from "uselocalstorage";
-
-function MyComponent() {
-  const [data, setData, setKey] = useLocalStorage("name", "");
-
-  return (
-    <>
-      <input
-        value={data}
-        onChange={(e) => {
-          setData(e.target.value);
-        }}
-      />
-      <button
-        onClick={() => {
-          setKey("email", "");
-        }}
-      >
-        Switch to Email
-      </button>
-    </>
-  );
-}
-```
-
-### Typescript Usage
-
-The `setKey` function works fine if your new `key` is of the same type as your original `key`; however, the `useLocalStorage` hook does not currently support switching keys if the new value is of a different type. Please file an issue if you'd like to contribute this enhancement!
-
-## Using a Different Serializer and/or Parser
-
-the `useLocalStorage` hook takes an optional third `options` argument. This allows you to configure a custom serializer and/or parser if you need to use something other than `JSON.stringify` and `JSON.parse`.
+the `useLocalStorage` hook takes an optional third `options` argument. This allows you to configure a custom serializer and/or parser if you need to use something other than `JSON.stringify` and `JSON.parse`. The `options` object also has a `logger` key to log an errors caught in the hook.
 
 ```javascript
 const options = {
@@ -126,6 +85,9 @@ const options = {
   parser: (str) => {
     /* Parse logic */
     return parsedObject;
+  },
+  logger: (error) => {
+    // Do some logging
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uselocalstorage",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A flexible React Hook for using Local Storage.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Simplifies hook interface. Ultimately, allowing the user to update the `key` wasn't very "typescripty."
- Bumps version to 2.0.0