### PR TITLE
Change react form direct to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "@types/testing-library__jest-dom": "^5.9.5",
     "jest": "^26.6.3",
     "jest-localstorage-mock": "^2.4.6",
-    "react-dom": "^17.0.1",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
   },
-  "dependencies": {
-    "react": "^17.0.1"
+  "peerDependencies": {
+    "react": ">=16.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-local-storage",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "A flexible React Hook for using Local Storage.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Issue

Issue #10

# Changes

- React just needs to be a peer dependency and only at v16..8.1 or higher