### PR TITLE
Avoid stale keys, defaultValue, etc

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,7 @@ function useLocalStorage<T>(
       if (e.key !== key || e.storageArea !== window.localStorage) return;
 
       try {
-        setValue(getValue(key, defaultValue));
+setValue(e.newValue ? parser(e.newValue) : undefined);
       } catch (e) {
         logger(e);
       }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type Serializer<T> = (object: T | undefined) => string;
 type Parser<T> = (val: string) => T | undefined;
@@ -13,56 +13,67 @@ type Options<T> = Partial<{
 
 function useLocalStorage<T>(
   key: string,
-  defaultValue: T,
-  options?: Options<T>
-): [T, Setter<T>];
-function useLocalStorage<T>(
-  key: string,
   defaultValue?: T,
   options?: Options<T>
-) {
+): [T, Setter<T>] {
   const opts = useMemo(() => {
     return {
       serializer: JSON.stringify,
       parser: JSON.parse,
       logger: console.log,
       syncData: true,
-      ...options,
+      ...options
     };
   }, [options]);
 
   const { serializer, parser, logger, syncData } = opts;
+  // The parser and logger are supposed to change very infrequently since
+  // they are memoized above; however the key and default value are not
+  // memoized in any way so we take them as params and expect the caller
+  // of this function to properly depend on them
+  const getValue = useCallback(
+    (key, defaultValue) => {
+      if (typeof window === "undefined") return defaultValue;
+      try {
+        const item = window.localStorage.getItem(key);
+        const res = item ? parser(item) : defaultValue;
 
-  const [storedValue, setValue] = useState(() => {
-    if (typeof window === "undefined") return defaultValue;
+        return res;
+      } catch (e) {
+        logger(e);
+        return defaultValue;
+      }
+    },
+    [parser, logger]
+  );
 
-    try {
-      const item = window.localStorage.getItem(key);
-      const res: T = item ? parser(item) : defaultValue;
-      return res;
-    } catch (e) {
-      logger(e);
-      return defaultValue;
-    }
-  });
+  const [storedValue, setValue] = useState(() => getValue(key, defaultValue));
+
+  // When any of the dependencies is updated, check
+  useEffect(() => {
+    setValue(getValue(key, defaultValue));
+  }, [getValue, key, defaultValue]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const updateLocalStorage = () => {
-      if (storedValue !== undefined) {
-        window.localStorage.setItem(key, serializer(storedValue));
-      } else {
+      if (storedValue === undefined) {
+        if (storedValue !== defaultValue) {
+          setValue(defaultValue);
+        }
         window.localStorage.removeItem(key);
+      } else {
+        window.localStorage.setItem(key, serializer(storedValue));
       }
-    }
+    };
 
     try {
       updateLocalStorage();
     } catch (e) {
       logger(e);
     }
-  }, [storedValue]);
+  }, [key, defaultValue, storedValue, logger, serializer]);
 
   useEffect(() => {
     if (!syncData) return;
@@ -71,7 +82,7 @@ function useLocalStorage<T>(
       if (e.key !== key || e.storageArea !== window.localStorage) return;
 
       try {
-        setValue(e.newValue ? parser(e.newValue) : undefined);
+        setValue(getValue(key, defaultValue));
       } catch (e) {
         logger(e);
       }
@@ -81,7 +92,7 @@ function useLocalStorage<T>(
 
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
-  }, [key, syncData]);
+  }, [getValue, key, defaultValue, logger, syncData]);
 
   return [storedValue, setValue];
 }

--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,7 @@ function useLocalStorage<T>(
 
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
-  }, [getValue, key, defaultValue, logger, syncData]);
+  }, [key, defaultValue, parser, logger, syncData]);
 
   return [storedValue, setValue];
 }

--- a/index.ts
+++ b/index.ts
@@ -82,7 +82,7 @@ function useLocalStorage<T>(
       if (e.key !== key || e.storageArea !== window.localStorage) return;
 
       try {
-setValue(e.newValue ? parser(e.newValue) : undefined);
+        setValue(e.newValue ? parser(e.newValue) : undefined);
       } catch (e) {
         logger(e);
       }


### PR DESCRIPTION
When the key changes dynamically, it still uses the old key since methods are not depending properly on the key. With this PR, when the key changes the methods change accordingly. It also avoid stale default values. TBH, the whole dependency was quite troublesome and I had to clean up a bunch of code.

Demo of this working PR:

https://codesandbox.io/s/dreamy-fermat-x3u9lu

Try changing the import from `"./use-local-storage"` to `"use-local-storage"` to see the broken bits.