### PR TITLE
Sync state globally and locally without extra re-renders

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -55,7 +55,7 @@ function useLocalStorage<T>(
       } else {
         window.localStorage.removeItem(key);
       }
-    }
+    };
 
     try {
       updateLocalStorage();
@@ -71,6 +71,8 @@ function useLocalStorage<T>(
       if (e.key !== key || e.storageArea !== window.localStorage) return;
 
       try {
+        // When the new value is the same as the old one, don't trigger an update
+        if (e.newValue === serializer(storedValue)) return;
         setValue(e.newValue ? parser(e.newValue) : undefined);
       } catch (e) {
         logger(e);
@@ -81,7 +83,7 @@ function useLocalStorage<T>(
 
     window.addEventListener("storage", handleStorageChange);
     return () => window.removeEventListener("storage", handleStorageChange);
-  }, [key, syncData]);
+  }, [key, syncData, storedValue]);
 
   return [storedValue, setValue];
 }

--- a/test/useLocalStorage.test.tsx
+++ b/test/useLocalStorage.test.tsx
@@ -77,20 +77,20 @@ function WithDisabedSync() {
 
 function WithMultipleSetterCallback() {
   const [data, setData] = useLocalStorage("username", "foo");
-  
+
   return (
     <>
       <p>{data}</p>
-      <button 
+      <button
         id="set-data-multiple-callback"
         onClick={() => {
           setData((data) => data + "bar");
           setData((data) => data + "bar");
           setData((data) => data + "bar");
           setData((data) => data + "bar");
-      }}
-    >
-      Change Username
+        }}
+      >
+        Change Username
       </button>
     </>
   );
@@ -107,6 +107,19 @@ function createStorageEventOption(
     oldValue: null,
     storageArea: storage ?? window.localStorage,
   });
+}
+
+function CountRenders({ counter }: { counter: { value: number } }) {
+  const [data, setData] = useLocalStorage("username", "foo");
+  counter.value++;
+  return (
+    <>
+      <p>{data}</p>
+      <button id="stability" onClick={() => setData((data) => data + "bar")}>
+        Change Username
+      </button>
+    </>
+  );
 }
 
 describe("useLocalStorage", () => {
@@ -156,7 +169,7 @@ describe("useLocalStorage", () => {
   it("changes localStorage and state value correctly for multiple setter callbacks", () => {
     const { container } = render(<WithMultipleSetterCallback />);
     fireEvent.click(container.querySelector("#set-data-multiple-callback")!);
-    expect(container.querySelector('p')).toHaveTextContent("foobarbarbarbar");
+    expect(container.querySelector("p")).toHaveTextContent("foobarbarbarbar");
     expect(localStorage.getItem("username")).toBe(
       JSON.stringify("foobarbarbarbar")
     );
@@ -246,8 +259,15 @@ describe("useLocalStorage", () => {
 
     fireEvent.click(container.querySelector("#remove-data")!);
     fireEvent.click(container.querySelector("#set-data")!);
-    expect(localStorage.getItem("username")).toBe(
-      JSON.stringify("Burt")
-    );
+    expect(localStorage.getItem("username")).toBe(JSON.stringify("Burt"));
+  });
+  it("triggers a re-render only the needed amount of times", () => {
+    const counter = { value: 0 };
+    expect(counter.value).toBe(0);
+    const { container } = render(<CountRenders counter={counter} />);
+    expect(counter.value).toBe(1);
+    fireEvent.click(container.querySelector("#stability")!);
+    expect(counter.value).toBe(2);
+    expect(localStorage.getItem("username")).toEqual(JSON.stringify("foobar"));
   });
 });


### PR DESCRIPTION
Built on top of PR #29, but avoid triggering unnecessary re-renders. Added test to count the re-renders to make sure it's as lean as possible (which passes with this PR, but doesn't pass with #29):

```js
  it("triggers a re-render only the needed amount of times", () => {
    const counter = { value: 0 };
    expect(counter.value).toBe(0);
    const { container } = render(<CountRenders counter={counter} />);
    expect(counter.value).toBe(1);  // Initial one
    fireEvent.click(container.querySelector("#stability")!);
    expect(counter.value).toBe(2);  // After an update
    expect(localStorage.getItem("username")).toEqual(JSON.stringify("foobar"));
  });
```

Sorry, tried to make a PR to the PR #29 to keep attribution but I didn't know how:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/2801252/233523158-fe9206b4-cc61-4c7c-b4be-43bbd24537f6.png">